### PR TITLE
Add basic daily planner with calendar links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,2 @@
-# This .gitignore is appropriate for repositories deployed to GitHub Pages and using
-# a Gemfile as specified at https://github.com/github/pages-gem#conventional
-
-# Basic Jekyll gitignores (synchronize to Jekyll.gitignore)
-_site/
-.sass-cache/
-.jekyll-cache/
-.jekyll-metadata
-
-# Additional Ruby/bundler ignore for when you run: bundle install
-/vendor
-
-# Specific ignore for GitHub Pages
-# GitHub Pages will always use its own deployed version of pages-gem 
-# This means GitHub Pages will NOT use your Gemfile.lock and therefore it is
-# counterproductive to check this file into the repository.
-# Details at https://github.com/github/pages-gem/issues/768
-Gemfile.lock
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # Daily-Planner
-Planner for daily tasks for people with ADHD.
+
+A lightweight daily planner aimed at users who benefit from structured days. It can
+export entries to CSV and provides links for adding events to popular calendars.
+A small cyberpunk-themed web interface is included for inspiration.
+
+## Features
+
+- Add tasks with a title, description and time range.
+- Export tasks to a CSV file for record keeping.
+- Generate links for Google Calendar and Outlook.
+- Generate ICS data that can be imported into iOS or Samsung calendars.
+- Fill empty hours with "fluff" entries to avoid overwhelming schedules.
+
+## Usage
+
+```python
+from datetime import datetime
+from planner import Task, DailyPlanner
+
+planner = DailyPlanner()
+planner.add_task(Task("Therapy", datetime(2024, 1, 1, 9), datetime(2024, 1, 1, 10)))
+planner.fill_with_fluff(datetime(2024, 1, 1))
+planner.export_csv("out.csv")
+```
+
+Run the tests with:
+
+```bash
+pytest
+```
+
+A static web prototype with a cyberpunk style lives in `web/index.html`.

--- a/planner/__init__.py
+++ b/planner/__init__.py
@@ -1,0 +1,109 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import List
+import csv
+import urllib.parse
+
+
+@dataclass
+class Task:
+    """Representation of a single planner entry."""
+
+    title: str
+    start: datetime
+    end: datetime
+    description: str = ""
+    category: str = "general"
+
+    def to_csv_row(self) -> List[str]:
+        """Return the task as a CSV row."""
+        return [
+            self.title,
+            self.start.isoformat(),
+            self.end.isoformat(),
+            self.description,
+            self.category,
+        ]
+
+    def google_link(self) -> str:
+        """Return a link for adding the event to Google Calendar."""
+        base = "https://calendar.google.com/calendar/render"
+        dates = f"{self.start.strftime('%Y%m%dT%H%M%S')}/{self.end.strftime('%Y%m%dT%H%M%S')}"
+        params = {
+            "action": "TEMPLATE",
+            "text": self.title,
+            "details": self.description,
+            "dates": dates,
+        }
+        return f"{base}?{urllib.parse.urlencode(params)}"
+
+    def outlook_link(self) -> str:
+        """Return a link for adding the event to Outlook."""
+        base = "https://outlook.live.com/owa/"
+        params = {
+            "path": "/calendar/action/compose",
+            "subject": self.title,
+            "body": self.description,
+            "startdt": self.start.isoformat(),
+            "enddt": self.end.isoformat(),
+        }
+        return f"{base}?{urllib.parse.urlencode(params)}"
+
+    def to_ics(self) -> str:
+        """Return an ICS representation of the event."""
+        lines = [
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "BEGIN:VEVENT",
+            f"SUMMARY:{self.title}",
+            f"DTSTART:{self.start.strftime('%Y%m%dT%H%M%S')}",
+            f"DTEND:{self.end.strftime('%Y%m%dT%H%M%S')}",
+            f"DESCRIPTION:{self.description}",
+            "END:VEVENT",
+            "END:VCALENDAR",
+        ]
+        return "\n".join(lines)
+
+
+@dataclass
+class DailyPlanner:
+    """Simple daily planner holding a list of tasks."""
+
+    tasks: List[Task] = field(default_factory=list)
+
+    def add_task(self, task: Task) -> None:
+        self.tasks.append(task)
+
+    def export_csv(self, path: str) -> None:
+        """Export all tasks to a CSV file."""
+        with open(path, "w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["title", "start", "end", "description", "category"])
+            for task in self.tasks:
+                writer.writerow(task.to_csv_row())
+
+    def fill_with_fluff(
+        self, day: datetime, start_hour: int = 8, end_hour: int = 20, fluff_title: str = "Break"
+    ) -> None:
+        """Fill empty hours in the day with placeholder tasks.
+
+        Parameters
+        ----------
+        day:
+            The day to inspect.
+        start_hour:
+            Starting hour for planning (inclusive).
+        end_hour:
+            Ending hour for planning (exclusive).
+        fluff_title:
+            Title used for the placeholder tasks.
+        """
+
+        current = datetime(day.year, day.month, day.day, start_hour)
+        last = datetime(day.year, day.month, day.day, end_hour)
+        while current < last:
+            overlap = any(task.start <= current < task.end for task in self.tasks)
+            if not overlap:
+                fluff = Task(fluff_title, current, current + timedelta(hours=1), category="fluff")
+                self.tasks.append(fluff)
+            current += timedelta(hours=1)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,33 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from planner import Task, DailyPlanner
+from datetime import datetime
+import csv
+import urllib.parse
+
+
+def test_export_csv(tmp_path):
+    planner = DailyPlanner()
+    task = Task("Test", datetime(2020, 1, 1, 9), datetime(2020, 1, 1, 10), "desc")
+    planner.add_task(task)
+    path = tmp_path / "out.csv"
+    planner.export_csv(path)
+    with open(path) as fh:
+        rows = list(csv.reader(fh))
+    assert rows[1][0] == "Test"
+
+
+def test_google_link():
+    task = Task("Meeting", datetime(2020, 1, 1, 9), datetime(2020, 1, 1, 10))
+    link = task.google_link()
+    assert "calendar.google.com" in link
+    assert urllib.parse.quote("Meeting") in link
+
+
+def test_fill_with_fluff():
+    day = datetime(2020, 1, 1)
+    planner = DailyPlanner()
+    planner.fill_with_fluff(day, start_hour=9, end_hour=11, fluff_title="Rest")
+    assert len(planner.tasks) == 2
+    assert all(t.title == "Rest" for t in planner.tasks)

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,3 @@
+// Minimal placeholder script for future enhancements.
+const planner = document.getElementById('planner');
+planner.innerHTML = '<p>Planner UI coming soon...</p>';

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cyberpunk Daily Planner</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Daily Planner</h1>
+  <p>Simple planner interface with a cyberpunk vibe.</p>
+  <div id="planner"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,14 @@
+body {
+  background-color: #0d0d0d;
+  color: #0ff;
+  font-family: 'Courier New', monospace;
+}
+
+h1 {
+  color: #f0f;
+  text-shadow: 0 0 5px #f0f;
+}
+
+#planner {
+  margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- add `Task` and `DailyPlanner` classes for managing tasks
- export tasks to CSV and generate Google/Outlook links and ICS data
- include cyberpunk-themed web prototype and basic tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af55cbcdbc83309ece434d14138858